### PR TITLE
GraphQL cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "type-check": "tsc",
     "lint": "prettier --write . && next lint --fix",
     "codegen": "graphql-codegen --config codegen.yml",
-    "postinstall": "yarn run update-schema",
     "update-schema": "export $(cat .env.local| xargs) && npx get-graphql-schema $NEXT_PUBLIC_SALEOR_URI > ./src/graphql/schema.graphql; npx zeus ./src/graphql/schema.graphql ./src/graphql/ --apollo"
   },
   "dependencies": {
@@ -35,6 +34,7 @@
     "eslint-config-next": "12.0.7",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
+    "graphql-zeus": "^4.0.4",
     "prettier": "2.5.1",
     "typescript": "4.5.4"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
+    "noUnusedParameters": false,
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1810,7 +1810,7 @@ create-require@^1.1.0:
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-cross-fetch@^3.0.6, cross-fetch@^3.1.5:
+cross-fetch@^3.0.4, cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
@@ -2638,6 +2638,13 @@ graphql-executor@0.0.18:
   resolved "https://registry.yarnpkg.com/graphql-executor/-/graphql-executor-0.0.18.tgz#6aa4b39e1ca773e159c2a602621e90606df0109a"
   integrity sha512-upUSl7tfZCZ5dWG1XkOvpG70Yk3duZKcCoi/uJso4WxJVT6KIrcK4nZ4+2X/hzx46pL8wAukgYHY6iNmocRN+g==
 
+graphql-js-tree@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/graphql-js-tree/-/graphql-js-tree-0.0.3.tgz#280a9e7a6acc951567470daafc904624cfa21d62"
+  integrity sha512-X/AhG+XRmRHCYQRLEbQxdODF16kE9w0b5lDMLJVSpcQlEum/+QeWuHky9hRGXw1apkREQdEtbZ5QXbr2t8v8/A==
+  dependencies:
+    graphql "^15.4.0"
+
 graphql-request@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-4.1.0.tgz#98d0d8d4458fd81674d8566d0b5781bd2823c26e"
@@ -2663,6 +2670,16 @@ graphql-ws@^5.4.1:
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/graphql-ws/-/graphql-ws-5.6.2.tgz#c7e5e382bd80d7fef637ea0b86ef4b1cb3d0b09b"
   integrity sha512-TsjovINNEGfv52uKWYSVCOLX9LFe6wAhf9n7hIsV3zjflky1dv/mAP+kjXAXsnzV1jH5Sx0S73CtBFNvxus+SQ==
+
+graphql-zeus@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/graphql-zeus/-/graphql-zeus-4.0.4.tgz#5d1d262d7f6bfe938877169881bed59f2d325f1e"
+  integrity sha512-M80E3xo19A40VGZjm1I1lFw41SQhAxo+qqavsyg4V974XW2CVCH00HmgHBGMtne5LfEbFgH9yi5Q4XdGjR8GTA==
+  dependencies:
+    cross-fetch "^3.0.4"
+    graphql "^15.4.0"
+    graphql-js-tree "0.0.3"
+    yargs "^16.1.1"
 
 graphql@^15.4.0:
   version "15.8.0"
@@ -4820,6 +4837,11 @@ yargs-parser@^18.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^20.2.2:
+  version "20.2.9"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
+  integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
 yargs-parser@^21.0.0:
   version "21.0.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.0.1.tgz#0267f286c877a4f0f728fceb6f8a3e4cb95c6e35"
@@ -4841,6 +4863,19 @@ yargs@^15.3.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^16.1.1:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-16.2.0.tgz#1c82bf0f6b6a66eafce7ef30e376f49a12477f66"
+  integrity sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
 
 yargs@^17.0.0:
   version "17.3.1"


### PR DESCRIPTION
3 things here:
 * `noUnusedParameters` set to `false`, as zeus-generated TS has some issues with it (and other files also), which is causing `yarn build` to fail
 * `graphql-zeus` added to `devDependenies` (otherwise running `npx zeus ...` is fetching https://www.npmjs.com/package/zeus) and that's not exactly the same package
 * removing `postinstall` - it will reerite zeus-generated files during deployment to Vercel, and we want to avoid that.