### PR TITLE
Use request's header to establish base URL

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,2 @@
-export const APP_DOMAIN = process.env.NEXT_PUBLIC_APP_DOMAIN;
 export const SALEOR_DOMAIN_HEADER = "x-saleor-domain";
 export const SALEOR_TOKEN_HEADER = "x-saleor-token";

--- a/src/pages/api/manifest.ts
+++ b/src/pages/api/manifest.ts
@@ -1,14 +1,20 @@
 import { NextApiRequest, NextApiResponse } from "next";
+
+import { getBaseURL } from "../../utils/middleware";
 import { version, name } from "../../../package.json";
 
+
+
 const handler = (_req: NextApiRequest, res: NextApiResponse) => {
+  const baseURL = getBaseURL(_req);
+
   const manifest = {
     id: "saleor.app",
     version: version,
     name: name,
     permissions: ["MANAGE_ORDERS"],
-    configurationUrl: `${process.env.NEXT_PUBLIC_APP_DOMAIN}/configuration`,
-    tokenTargetUrl: `${process.env.NEXT_PUBLIC_APP_DOMAIN}/api/register`,
+    configurationUrl: `${baseURL}/configuration`,
+    tokenTargetUrl: `${baseURL}/api/register`,
   };
   res.end(JSON.stringify(manifest));
 };

--- a/src/pages/api/register.ts
+++ b/src/pages/api/register.ts
@@ -6,6 +6,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { SALEOR_DOMAIN_HEADER } from "../../constants";
 import { createWebhook } from "../../graphql/data/mutations/webhook";
 import { saleor } from "../../graphql/client";
+import { getBaseURL } from "../../utils/middleware";
 
 const handler = async (
   request: NextApiRequest,
@@ -37,7 +38,7 @@ const handler = async (
     mutation: createWebhook,
     variables: {
       name: "Best app: Product updated",
-      targetUrl: `${process.env.NEXT_PUBLIC_APP_DOMAIN}/api/webhooks/product-updated`,
+      targetUrl: `${getBaseURL(request)}/api/webhooks/product-updated`,
       events: WebhookEventTypeEnum.ProductUpdated,
       secretKey: process.env.SECRET,
     },

--- a/src/utils/middleware.ts
+++ b/src/utils/middleware.ts
@@ -1,3 +1,4 @@
+import { NextApiRequest } from "next";
 import Cors from "cors";
 
 export default function initMiddleware(middleware: any) {
@@ -17,3 +18,8 @@ export const corsPost = initMiddleware(
     methods: ["POST"],
   })
 );
+
+export const getBaseURL = (req: NextApiRequest): string => {
+  const { host, "x-forwarded-proto": protocol = "http" } = req.headers;
+  return `${protocol}://${host}`;
+};


### PR DESCRIPTION
In this pull request I want to introduce simpler approach to problem of establishing base URL (used in e.g. manifest definition).

# Problem
When deploying new Vercel project, it's production deployment gets 5 domains in `vercel.app` zone:
 * [Automatic URLs](https://vercel.com/docs/concepts/deployments/automatic-urls#) (e.g.: https://saleor-best-app-kozval1sp-tomaszmagulski-saleorio.vercel.app/)
 * [Automatic Branch URLs](https://vercel.com/docs/concepts/deployments/automatic-urls#automatic-branch-urls) (e.g.: https://saleor-best-app-git-main-tomaszmagulski-saleorio.vercel.app/)
 * [Automatic Project URLs](https://vercel.com/docs/concepts/deployments/automatic-urls#automatic-project-urls) (e.g.: https://saleor-best-app-tomaszmagulski-saleorio.vercel.app/)
 * [Automatic Team Member URLs](https://vercel.com/docs/concepts/deployments/automatic-urls#automatic-team-member-urls) (which is not available in Vercel UI AFAIK I wasn't able to build example of such domain)
 * [Custom Domain](https://vercel.com/docs/concepts/projects/custom-domains) (which is also in `vercel.app` zone, containing project name and optional suffix).

The problem we're facing is, that `deployment-url` attached to [Redirect URL](https://vercel.com/docs/deploy-button#callback/redirect-url), when deploying using Deploy Button is set to this custom domain.

So to simplify process of deployment apps using Marketplace, we want to:
 * Install app using Deploy Button
 * Get Vercel-issued Custom Domain and run `installApp` mutation using manifest location in this Custom Domain
 * Ensure, that all registered webhooks and dashboard extensions are served using that Custom Domain.

# Other valid approach
Use `VERCEL_URL` environment variable (that's unique for every deployment), figure out [Automatic Project URLs](https://vercel.com/docs/concepts/deployments/automatic-urls#automatic-project-urls) and use it as canonical URL for that app's deployment.
Workflow would look like:
 * Install app using Deploy Button
 * Get Vercel-issued Custom Domain (from query parameter provided by [Redirect URL](https://vercel.com/docs/deploy-button#callback/redirect-url)) and run `installApp` mutation using manifest location in this Custom Domain
 * Ensure, that all registered webhooks and dashboard extensions are serverd using Active Project URL.

# Rejected approaches
 * Using `VERCEL_URL` directly (as it's permanent value for every deployment, so if we will register webhooks and dashboard extensions using it and customer will push additional commits to it's app's fork, Saleor environment will use app from outdated commit)
 * Using custom environment variable/domain (as for the time being we want make apps' installation as straightforward, as we can from Marketplace)